### PR TITLE
Rename freedom to hugo-theme-freedom

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-# Contributing to Hugo Freedom Theme
+# Contributing to Hugo Theme Freedom
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -29,23 +29,27 @@ for all involved. The community looks forward to your contributions. 🎉
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+
 - [I Have a Question](#i-have-a-question)
+
 - [I Want To Contribute](#i-want-to-contribute)
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements](#suggesting-enhancements)
+
+  - [Reporting Bugs](#reporting-bugs)
+
+  - [Suggesting Enhancements](#suggesting-enhancements)
 
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Hugo Freedom Theme Code of Conduct](./CODE_OF_CONDUCT.md). By participating,
+[Hugo Theme Freedom Code of Conduct](./CODE_OF_CONDUCT.md). By participating,
 you are expected to uphold this code. Please report unacceptable behavior to
 <vasco@guita.org>.
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/vascoguita/freedom/wiki).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/vascoguita/hugo-theme-freedom/wiki).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/vascoguita/freedom/issues)
+Before you ask a question, it is best to search for existing [Issues](https://github.com/vascoguita/hugo-theme-freedom/issues)
 that might help you. In case you have found a suitable issue and still need
 clarification, you can write your question in this issue. It is also advisable
 to search the internet for answers first.
@@ -53,7 +57,7 @@ to search the internet for answers first.
 If you then still feel the need to ask a question and need clarification, we
 recommend the following:
 
-- Open an [Issue](https://github.com/vascoguita/freedom/issues/new).
+- Open an [Issue](https://github.com/vascoguita/hugo-theme-freedom/issues/new).
 
 - Provide as much context as you can about what you're running into.
 
@@ -80,13 +84,12 @@ steps in advance to help us fix any potential bug as fast as possible.
 
 - Determine if your bug is really a bug and not an error on your side e.g. using
   incompatible environment components/versions (Make sure that you have read the
-  [documentation](https://github.com/vascoguita/freedom/wiki). If you are
-  looking for support, you might want to check
-  [this section](#i-have-a-question)).
+  [documentation](https://github.com/vascoguita/hugo-theme-freedom/wiki). If you
+  are looking for support, you might want to check [this section](#i-have-a-question)).
 
 - To see if other users have experienced (and potentially already solved) the
   same issue you are having, check if there is not already a bug report existing
-  for your bug or error in the [bug tracker](https://github.com/vascoguita/freedom/issues?q=label%3Abug).
+  for your bug or error in the [bug tracker](https://github.com/vascoguita/hugo-theme-freedom/issues?q=label%3Abug).
 
 - Also make sure to search the internet (including Stack Overflow) to see if
   users outside of the GitHub community have discussed the issue.
@@ -114,7 +117,7 @@ steps in advance to help us fix any potential bug as fast as possible.
 We use GitHub issues to track bugs and errors. If you run into an issue with the
 project:
 
-- Open an [Issue](https://github.com/vascoguita/freedom/issues/new).
+- Open an [Issue](https://github.com/vascoguita/hugo-theme-freedom/issues/new).
 
 - Explain the behavior you would expect and the actual behavior.
 
@@ -128,7 +131,7 @@ project:
 ### Suggesting Enhancements
 
 This section guides you through submitting an enhancement suggestion for Hugo
-Freedom Theme, **including completely new features and minor improvements to
+Theme Freedom, **including completely new features and minor improvements to
 existing functionality**. Following these guidelines will help maintainers and
 the community to understand your suggestion and find related suggestions.
 
@@ -136,13 +139,13 @@ the community to understand your suggestion and find related suggestions.
 
 - Make sure that you are using the latest version.
 
-- Read the [documentation](https://github.com/vascoguita/freedom/wiki) carefully
-  and find out if the functionality is already covered, maybe by an individual
-  configuration.
+- Read the [documentation](https://github.com/vascoguita/hugo-theme-freedom/wiki)
+  carefully and find out if the functionality is already covered, maybe by an
+  individual configuration.
 
-- Perform a [search](https://github.com/vascoguita/freedom/issues) to see if the
-  enhancement has already been suggested. If it has, add a comment to the
-  existing issue instead of opening a new one.
+- Perform a [search](https://github.com/vascoguita/hugo-theme-freedom/issues) to
+  see if the enhancement has already been suggested. If it has, add a comment to
+  the existing issue instead of opening a new one.
 
 - Find out whether your idea fits with the scope and aims of the project. It's
   up to you to make a strong case to convince the project's developers of the
@@ -152,7 +155,7 @@ the community to understand your suggestion and find related suggestions.
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/vascoguita/freedom/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/vascoguita/hugo-theme-freedom/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the
   suggestion.
@@ -168,7 +171,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/vascog
   demonstrate the steps or point out the part which the suggestion is related
   to.
 
-- **Explain why this enhancement would be useful** to most Hugo Freedom Theme
+- **Explain why this enhancement would be useful** to most Hugo Theme Freedom
   users. You may also want to point out the other projects that solved it better
   and which could serve as inspiration.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,7 @@ Closes #ISSUE-NUMBER
 ## Summary of changes
 
 -
+
 -
+
 -

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,8 +8,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## Supported Versions
 
-Only the [latest version](https://github.com/vascoguita/freedom/releases/latest)
-of the Freedom theme is being supported with security updates.
+Only the [latest version](https://github.com/vascoguita/hugo-theme-freedom/releases/latest)
+of Hugo Theme Freedom is being supported with security updates.
 
 ## Reporting a Vulnerability
 
@@ -17,4 +17,4 @@ To report a vulnerability, please send an email to <vasco@guita.org> providing
 an explanation of the issue, the steps to reproduce it and, if possible, a
 security patch.
 If no answer is receive within 42 hours or no patch is provided within 72 hours,
-please [create an issue](https://github.com/vascoguita/freedom/issues/new).
+please [create an issue](https://github.com/vascoguita/hugo-theme-freedom/issues/new).

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-# Hugo Freedom Theme
+# Hugo Theme Freedom
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](.github/CODE_OF_CONDUCT.md)
-[![Lint YAML](https://github.com/vascoguita/freedom/actions/workflows/lint-yaml.yaml/badge.svg)](https://github.com/vascoguita/freedom/actions/workflows/lint-yaml.yaml)
-[![Lint Markdown](https://github.com/vascoguita/freedom/actions/workflows/lint-markdown.yaml/badge.svg)](https://github.com/vascoguita/freedom/actions/workflows/lint-markdown.yaml)
-[![Lint Makefile](https://github.com/vascoguita/freedom/actions/workflows/lint-makefile.yaml/badge.svg)](https://github.com/vascoguita/freedom/actions/workflows/lint-makefile.yaml)
-[![Check License Headers](https://github.com/vascoguita/freedom/actions/workflows/check-license-headers.yaml/badge.svg)](https://github.com/vascoguita/freedom/actions/workflows/check-license-headers.yaml)
+[![Lint YAML](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-yaml.yaml/badge.svg)](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-yaml.yaml)
+[![Lint Markdown](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-markdown.yaml/badge.svg)](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-markdown.yaml)
+[![Lint Makefile](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-makefile.yaml/badge.svg)](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/lint-makefile.yaml)
+[![Check License Headers](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/check-license-headers.yaml/badge.svg)](https://github.com/vascoguita/hugo-theme-freedom/actions/workflows/check-license-headers.yaml)
 
 A minimalist [Hugo](https://gohugo.io) theme built with [Bootstrap](https://getbootstrap.com).


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vasco Guita <vasco@guita.org>

SPDX-License-Identifier: CC-BY-4.0
-->

# Solved issue

Closes #21 

## Summary of changes

- Rename freedom to hugo-theme-freedom.

- Rename Hugo Freedom Theme to Hugo Theme Freedom.

- Add spaces between Markdown list items.
